### PR TITLE
add G-Code Thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Install Python 3.8 by your preferred means, then run the mbotmake file in the ro
 ## Windows
 Download the exe from [here](https://github.com/sckunkle/mbotmake/releases) and drag and drop your gcode onto the executable.
 
-## G-Code Thumbnails (only PrusaSlicer)
-Add "55x40, 110x80, 320x200" to Printer Settings -> G-code thumbnails.
+## PrusaSlicer
+Change these two settings in PrusaSlicer:
+* Runs mbotmake automatically after exporting G-Code.<br><strong>[Print Settings] &rarr; [Output options] &rarr; [Post-processing scripts]:</strong><br>'[path to python] [.../]mbotmake.py -prusa'
+* Generates the thumbnails for the Makerbot Replicator Gen5 display.<br><strong>[Printer Settings] &rarr; [General] &rarr; [G-code thumbnails]:</strong><br>
+'55x40, 110x80, 320x200'
 
 # PLANNED FEATURES
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Install Python 3.8 by your preferred means, then run the mbotmake file in the ro
 ## Windows
 Download the exe from [here](https://github.com/sckunkle/mbotmake/releases) and drag and drop your gcode onto the executable.
 
+## G-Code Thumbnails (only PrusaSlicer)
+Add "55x40, 110x80, 320x200" to Printer Settings -> G-code thumbnails.
+
 # PLANNED FEATURES
 
 * Create a Ultimaker Cura plugin

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Download the exe from [here](https://github.com/sckunkle/mbotmake/releases) and 
 
 ## PrusaSlicer
 Change these two settings in PrusaSlicer:
-* Runs mbotmake automatically after exporting G-Code.<br><strong>[Print Settings] &rarr; [Output options] &rarr; [Post-processing scripts]:</strong><br>'[path to python] [.../]mbotmake.py -prusa'
+* Runs mbotmake automatically after exporting G-Code.<br><strong>[Print Settings] &rarr; [Output options] &rarr; [Post-processing scripts]:</strong><br>'[path to python] [.../]mbotmake -prusa'
 * Generates the thumbnails for the Makerbot Replicator Gen5 display.<br><strong>[Printer Settings] &rarr; [General] &rarr; [G-code thumbnails]:</strong><br>
 '55x40, 110x80, 320x200'
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Download the exe from [here](https://github.com/sckunkle/mbotmake/releases) and 
 
 ## PrusaSlicer
 Change these two settings in PrusaSlicer:
-* Runs mbotmake automatically after exporting G-Code.<br><strong>[Print Settings] &rarr; [Output options] &rarr; [Post-processing scripts]:</strong><br>'[path to python] [.../]mbotmake -prusa'
+* Runs mbotmake automatically after exporting G-Code.<br><strong>[Print Settings] &rarr; [Output options] &rarr; [Post-processing scripts]:</strong><br>'[path to python] [.../]mbotmake.py -prusa'
 * Generates the thumbnails for the Makerbot Replicator Gen5 display.<br><strong>[Printer Settings] &rarr; [General] &rarr; [G-code thumbnails]:</strong><br>
 '55x40, 110x80, 320x200'
 

--- a/mbotmake
+++ b/mbotmake
@@ -9,7 +9,7 @@ import math
 import re
 import traceback
 import base64
-
+from os import getenv
 
 def generateMetajson(temp, vardict):
     meta = """
@@ -265,9 +265,16 @@ def packageMBotFile(filename, temp, tnNames):
 
 def main(argv):
     try:
+        prusaScript = False         
         for gcode in argv[1:]:
             temp = tempfile.mkdtemp()
-            output = gcode.replace('.gcode', '.makerbot')
+            if "-prusa" in gcode:       # use "-prusa" as argument in PrusaSlicer Post-Processing-Script
+                prusaScript = True
+                continue
+            if prusaScript:
+                output  = str(getenv('SLIC3R_PP_OUTPUT_NAME')).replace('.gcode', '.makerbot')
+            else:
+                output = gcode.replace('.gcode', '.makerbot')
             print('Generating toolpath for', output)
             vardict = createToolpath(gcode, temp)
             print('Generating metadata for', output)

--- a/mbotmake
+++ b/mbotmake
@@ -8,6 +8,7 @@ import copy
 import math
 import re
 import traceback
+import base64
 
 
 def generateMetajson(temp, vardict):
@@ -48,6 +49,34 @@ def generateCommand(function, metadata, parameters, tags):
             }
         }
     ])
+
+
+def generateThumbnails(filename, temp):
+    tnNames = []
+    file = open(filename, 'r')
+    line = file.readline()
+    if "PrusaSlicer" not in line:  # only tested on Prusa Slicer
+        return tnNames;
+    while True: 
+        line = file.readline()
+        if "thumbnail begin" in line:
+            thumbnailMeta = line.split(' ')
+            thumbnailSize = thumbnailMeta[3]
+
+            line = file.readline()
+            thumbnail_data = ""
+            while "thumbnail end" not in line and line:
+                thumbnail_data = thumbnail_data + line.strip("; \n")
+                line = file.readline()
+            decoded_data = base64.b64decode(thumbnail_data)
+            thumbnailFileName = '{}/thumbnail_' + thumbnailSize  + '.png'
+            tnNames.append(thumbnailFileName)
+            with open(thumbnailFileName.format(temp), 'wb') as thumbnailFile:
+                thumbnailFile.write(decoded_data)
+        if not line:
+            break;
+    file.close();
+    return tnNames
 
 
 def computeTime(prev, current):
@@ -225,8 +254,10 @@ def createToolpath(filename, temp):
     return printersettings
 
 
-def packageMBotFile(filename, temp):
+def packageMBotFile(filename, temp, tnNames):
     with zipfile.ZipFile(filename, 'w', compression=zipfile.ZIP_DEFLATED) as mbotfile:
+        for tn in tnNames:
+            mbotfile.write(tn.format(temp), arcname=tn.strip("{}/"))
         mbotfile.write('{}/meta.json'.format(temp), arcname='meta.json')
         mbotfile.write('{}/print.jsontoolpath'.format(temp), arcname='print.jsontoolpath')
     return
@@ -241,8 +272,11 @@ def main(argv):
             vardict = createToolpath(gcode, temp)
             print('Generating metadata for', output)
             generateMetajson(temp, vardict)
+            print('Generating thumbnails for', output)
+            tnNames = generateThumbnails(gcode, temp)
+            print(len(tnNames), 'Thumbnail(s) generated')
             print('Packaging', output)
-            packageMBotFile(output, temp)
+            packageMBotFile(output, temp, tnNames)
             print(output, 'done!')
     except Exception as e:
         print()


### PR DESCRIPTION
This PR adds thumbnails to the .makerbot file for the MakerBot Replicator 5th Gen. It uses G-Code Thumbnails generated with PrasaSlicer, that are embedded in the .gcode file.